### PR TITLE
feat: 유저 프로필 사진 필드 추가, 회원 검색 기능 추가

### DIFF
--- a/api/user.py
+++ b/api/user.py
@@ -1,16 +1,20 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query, HTTPException
 from core.deps import get_current_user
 from models.model import UserEntity
-from schemas.user import DeleteUserResponse, NicknameUpdateRequest, NicknameUpdateResponse, PasswordUpdateRequest, PasswordUpdateResponse
+from schemas.user import DeleteUserResponse, NicknameUpdateRequest, NicknameUpdateResponse, PasswordUpdateRequest, PasswordUpdateResponse, UserProfileImageUpdate
 from crud.user import delete_user, update_user_nickname, update_user_password
 from db.database import get_db
 from sqlalchemy.orm import Session
-
+from enum import Enum
 
 router = APIRouter(
     prefix="/api/user",
     tags=["user"]
 )
+
+class SearchType(str, Enum):
+    nickname = "nickname"
+    email = "email"
 
 @router.post("/update-password", response_model=PasswordUpdateResponse)
 def update_password(
@@ -35,3 +39,70 @@ def delete_account(
     db: Session = Depends(get_db)
 ):
     return delete_user(current_user.user_id, db)
+
+@router.post("/profile-image")
+def update_profile_image(
+    payload: UserProfileImageUpdate,
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    try:
+        current_user.profile_image_url = payload.profile_image_url
+        db.commit()
+        db.refresh(current_user)
+        return {
+            "success": True,
+            "error": None
+        }
+    except Exception as e:
+        db.rollback()
+        return {
+            "success": False,
+            "error": str(e)
+        }
+
+@router.get("/search")
+def search_users(
+    keyword: str = Query(..., min_length=1),
+    type: SearchType = Query(..., description="검색 타입: nickname 또는 email"),
+    limit: int = Query(10, le=50, description="한 페이지당 결과 수"),
+    offset: int = Query(0, description="건너뛸 유저 수"),
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)  # ✅ JWT 인증 필요
+):
+    try:
+        query = db.query(UserEntity)
+
+        if type == SearchType.nickname:
+            query = query.filter(UserEntity.nickname.like(f"%{keyword}%"))
+        elif type == SearchType.email:
+            query = query.filter(UserEntity.email.like(f"%{keyword}%"))
+
+        total = query.count()
+        users = query.offset(offset).limit(limit).all()
+
+        result = [
+            {
+                "userId": user.user_id,
+                "username": user.email,
+                "nickname": user.nickname,
+                "profileImageUrl": user.profile_image_url
+            }
+            for user in users
+        ]
+
+        return {
+            "success": True,
+            "data": {
+                "users": result,
+                "total": total
+            },
+            "error": None
+        }
+
+    except Exception as e:
+        return {
+            "success": False,
+            "data": None,
+            "error": str(e)
+        }

--- a/models/model.py
+++ b/models/model.py
@@ -11,11 +11,12 @@ class UserEntity(Base):
     __tablename__ = "UserEntity"
 
     user_id = Column(Integer, primary_key=True, autoincrement=True, index=True)
-    email = Column(String(20), nullable=True)
+    email = Column(String(100), nullable=True)
     password = Column(String(256), nullable=True)
     name = Column(String(10), nullable=True)
     nickname = Column(String(10), nullable=True)
     phone = Column(String(11), nullable=True)
+    profile_image_url = Column(String(512), nullable=True)
     createdAt = Column(DateTime(timezone=True), server_default=func.now())
     updatedAt = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -21,6 +21,9 @@ class PasswordUpdateResponse(BaseModel):
     data: Optional[Dict[str, str]]
     error: Optional[str]
 
+class UserProfileImageUpdate(BaseModel):
+    profile_image_url: str
+
 #닉네임 변경 스키마
 class NicknameUpdateRequest(BaseModel):
     nickname: str


### PR DESCRIPTION
## 🔀 PR 유형
- [ ] FIX (버그 수정)
- [x] FEAT (신규 기능)

## 📌 PR 목적
- 유저 스키마에 "프로필 사진 URL" 필드 추가
- 회원 검색 기능 추가

## 📝 주요 변경 사항
- 프론트엔드에서 JWT 토큰과 함께 URL을 request하면 URL을 해당하는 유저의 필드에 저장합니다.
- 유저 정보 중, 이메일이나 닉네임(searchtype 선택하여야 함)으로 유저 리스트를 검색 후 반환합니다.
- 반환받는 정보는 프로필 사진, 이메일, 닉네임, userID입니다.
- userID를 통해 팔로우 요청을 보낼 수 있게 될 예정입니다.
<img width="1429" height="660" alt="image" src="https://github.com/user-attachments/assets/08251e0b-95e7-4c65-8ed2-ee6658004072" />


## ✅ 체크리스트
- [ ] 동일 상황에서 재현되지 않음 확인  
- [x] 단위 테스트/수동 테스트 통과  
- [ ] 문서(README 등) 업데이트  
- [x] 스크린샷/동영상 첨부 (필요 시)  

## 🔍 검토 요청
- 리뷰어: @PokingTeemo 
