### PR TITLE
feat : 팔로우 기능, 공개설정 보기설정 기능 구현

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -51,6 +51,11 @@ def get_my_profile(current_user: UserEntity = Depends(get_current_user)):
         "user_id": current_user.user_id,
         "email": current_user.email,
         "name": current_user.name,
+        "nickname": current_user.nickname,
+        "phone": current_user.phone,
+        "profile_image_url": current_user.profile_image_url,
+        "privacy_settings": current_user.privacy_settings,
+        "view_settings": current_user.view_settings
     }
 
 @router.post("/send-mail")

--- a/api/routes/follow.py
+++ b/api/routes/follow.py
@@ -1,0 +1,220 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.orm import Session
+from db.database import get_db
+from models.model import FollowEntity, UserEntity
+from core.deps import get_current_user
+from schemas.follow import FollowActionResponse, FollowListResponse, FollowUserSummary
+
+follow_router = APIRouter(tags=["follow"])  # ✅ prefix 제거
+
+@follow_router.post("/follow/{user_id}", response_model=FollowActionResponse)
+def follow_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    if current_user.user_id == user_id:
+        return FollowActionResponse(success=False, error="자기 자신은 팔로우할 수 없습니다.")
+
+    target_user = db.query(UserEntity).filter_by(user_id=user_id).first()
+    if not target_user:
+        return FollowActionResponse(success=False, error="대상 유저가 존재하지 않습니다.")
+
+    existing = db.query(FollowEntity).filter_by(
+        follower_id=current_user.user_id,
+        following_id=user_id
+    ).first()
+    if existing:
+        return FollowActionResponse(success=False, error="이미 팔로우 요청을 보냈거나 팔로우 중입니다.")
+
+    if target_user.privacy_settings == "closed":
+        return FollowActionResponse(success=False, error="해당 유저는 팔로우 요청을 받을 수 없습니다.")
+    
+    is_approved = target_user.privacy_settings == "open"
+
+    new_follow = FollowEntity(
+        follower_id=current_user.user_id,
+        following_id=user_id,
+        is_approved=is_approved
+    )
+
+    try:
+        db.add(new_follow)
+        db.commit()
+        return FollowActionResponse(success=True, error=None)
+    except Exception as e:
+        db.rollback()
+        return FollowActionResponse(success=False, error=str(e))
+
+
+@follow_router.post("/unfollow/{user_id}", response_model=FollowActionResponse)
+def unfollow_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    follow = db.query(FollowEntity).filter_by(
+        follower_id=current_user.user_id,
+        following_id=user_id
+    ).first()
+
+    if not follow:
+        return FollowActionResponse(success=False, error="팔로우 관계가 존재하지 않습니다.")
+
+    try:
+        db.delete(follow)
+        db.commit()
+        return FollowActionResponse(success=True, error=None)
+    except Exception as e:
+        db.rollback()
+        return FollowActionResponse(success=False, error=str(e))
+
+@follow_router.post("/accept/{user_id}", response_model=FollowActionResponse)
+def accept_follow_request(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    follow = db.query(FollowEntity).filter_by(
+        follower_id=user_id,
+        following_id=current_user.user_id
+    ).first()
+
+    if not follow:
+        return FollowActionResponse(success=False, error="팔로우 요청이 존재하지 않습니다.")
+
+    if follow.is_approved:
+        return FollowActionResponse(success=False, error="이미 승인된 팔로우입니다.")
+
+    try:
+        follow.is_approved = True
+        db.commit()
+        return FollowActionResponse(success=True, error=None)
+    except Exception as e:
+        db.rollback()
+        return FollowActionResponse(success=False, error=str(e))
+
+
+@follow_router.post("/decline/{user_id}", response_model=FollowActionResponse)
+def decline_follow_request(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    follow = db.query(FollowEntity).filter_by(
+        follower_id=user_id,
+        following_id=current_user.user_id
+    ).first()
+
+    if not follow:
+        return FollowActionResponse(success=False, error="팔로우 요청이 존재하지 않습니다.")
+
+    if follow.is_approved:
+        return FollowActionResponse(success=False, error="이미 승인된 팔로우는 거절할 수 없습니다.")
+
+    try:
+        db.delete(follow)
+        db.commit()
+        return FollowActionResponse(success=True, error=None)
+    except Exception as e:
+        db.rollback()
+        return FollowActionResponse(success=False, error=str(e))
+
+@follow_router.post("/defollow/{user_id}", response_model=FollowActionResponse)
+def defollow_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    follow = db.query(FollowEntity).filter_by(
+        follower_id=user_id,
+        following_id=current_user.user_id
+    ).first()
+
+    if not follow:
+        return FollowActionResponse(success=False, error="해당 유저는 현재 나를 팔로우하고 있지 않습니다.")
+
+    try:
+        db.delete(follow)
+        db.commit()
+        return FollowActionResponse(success=True, error=None)
+    except Exception as e:
+        db.rollback()
+        return FollowActionResponse(success=False, error=str(e))
+    
+@follow_router.get("/follows", response_model=FollowListResponse)
+def get_followings(
+    limit: int = Query(10, le=50),
+    offset: int = Query(0),
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    try:
+        query = db.query(FollowEntity).filter(FollowEntity.follower_id == current_user.user_id)
+        total = query.count()
+
+        follows = query.offset(offset).limit(limit).all()
+
+        result = []
+        for follow in follows:
+            user = db.query(UserEntity).filter_by(user_id=follow.following_id).first()
+            result.append({
+                "email": user.email,
+                "nickname": user.nickname,
+                "profileImageUrl": user.profile_image_url,
+                "status": "approved" if follow.is_approved else "pending"
+            })
+
+        return {
+            "success": True,
+            "data": {
+                "users": result,
+                "total": total
+            },
+            "error": None
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "data": None,
+            "error": str(e)
+        }
+
+
+@follow_router.get("/followers", response_model=FollowListResponse)
+def get_followers(
+    limit: int = Query(10, le=50),
+    offset: int = Query(0),
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    try:
+        query = db.query(FollowEntity).filter(FollowEntity.following_id == current_user.user_id)
+        total = query.count()
+
+        follows = query.offset(offset).limit(limit).all()
+
+        result = []
+        for follow in follows:
+            user = db.query(UserEntity).filter_by(user_id=follow.follower_id).first()
+            result.append({
+                "email": user.email,
+                "nickname": user.nickname,
+                "profileImageUrl": user.profile_image_url,
+                "status": "approved" if follow.is_approved else "pending"
+            })
+
+        return {
+            "success": True,
+            "data": {
+                "users": result,
+                "total": total
+            },
+            "error": None
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "data": None,
+            "error": str(e)
+        }

--- a/api/user.py
+++ b/api/user.py
@@ -1,16 +1,19 @@
 from fastapi import APIRouter, Depends, Query, HTTPException
 from core.deps import get_current_user
 from models.model import UserEntity
-from schemas.user import DeleteUserResponse, NicknameUpdateRequest, NicknameUpdateResponse, PasswordUpdateRequest, PasswordUpdateResponse, UserProfileImageUpdate
+from schemas.user import DeleteUserResponse, NicknameUpdateRequest, NicknameUpdateResponse, PasswordUpdateRequest, PasswordUpdateResponse, UserProfileImageUpdate, PrivacyUpdateRequest, StandardResponse
 from crud.user import delete_user, update_user_nickname, update_user_password
 from db.database import get_db
 from sqlalchemy.orm import Session
 from enum import Enum
+from api.routes.follow import follow_router  # ✅ follow 라우터 import
 
 router = APIRouter(
     prefix="/api/user",
     tags=["user"]
 )
+
+router.include_router(follow_router)
 
 class SearchType(str, Enum):
     nickname = "nickname"
@@ -71,7 +74,7 @@ def search_users(
     current_user: UserEntity = Depends(get_current_user)  # ✅ JWT 인증 필요
 ):
     try:
-        query = db.query(UserEntity)
+        query = db.query(UserEntity).filter(UserEntity.privacy_settings != 'closed')
 
         if type == SearchType.nickname:
             query = query.filter(UserEntity.nickname.like(f"%{keyword}%"))
@@ -106,3 +109,34 @@ def search_users(
             "data": None,
             "error": str(e)
         }
+
+    
+@router.post("/update-privacy", response_model=StandardResponse)
+def update_privacy(
+    payload: PrivacyUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    try:
+        current_user.privacy_settings = payload.privacy_settings
+        db.commit()
+        return {"success": True, "error": None}
+    except Exception as e:
+        db.rollback()
+        return {"success": False, "error": str(e)}
+    
+from schemas.user import ViewUpdateRequest
+
+@router.post("/update-view", response_model=StandardResponse)
+def update_view_settings(
+    payload: ViewUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: UserEntity = Depends(get_current_user)
+):
+    try:
+        current_user.view_settings = payload.view_settings
+        db.commit()
+        return {"success": True, "error": None}
+    except Exception as e:
+        db.rollback()
+        return {"success": False, "error": str(e)}

--- a/models/model.py
+++ b/models/model.py
@@ -17,6 +17,9 @@ class UserEntity(Base):
     nickname = Column(String(10), nullable=True)
     phone = Column(String(11), nullable=True)
     profile_image_url = Column(String(512), nullable=True)
+    privacy_settings = Column(String(10), nullable=False, default="open")  # "open", "semi", "closed"
+    view_settings = Column(String(10), nullable=False, default="all")  # "all" | "follows" | "self"
+
     createdAt = Column(DateTime(timezone=True), server_default=func.now())
     updatedAt = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
@@ -125,7 +128,10 @@ class FollowEntity(Base):
 
     follower_id = Column(Integer, ForeignKey("UserEntity.user_id"), primary_key=True)
     following_id = Column(Integer, ForeignKey("UserEntity.user_id"), primary_key=True)
+    is_approved = Column(Boolean, nullable=False, default=False)
+
     createdAt = Column(DateTime(timezone=True), server_default=func.now())
+    updatedAt = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     follower = relationship("UserEntity", foreign_keys=[follower_id], back_populates="followings")
     following = relationship("UserEntity", foreign_keys=[following_id], back_populates="followers")

--- a/schemas/follow.py
+++ b/schemas/follow.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import Optional, Literal
+
+class FollowActionResponse(BaseModel):
+    success: bool
+    error: Optional[str] = None
+
+class FollowUserSummary(BaseModel):
+    email: str
+    nickname: str
+    profileImageUrl: Optional[str]
+    status: Literal["pending", "approved"]
+
+class FollowListResponse(BaseModel):
+    success: bool
+    data: Optional[dict]
+    error: Optional[str]

--- a/schemas/user.py
+++ b/schemas/user.py
@@ -1,5 +1,12 @@
-from pydantic import BaseModel, EmailStr
-from typing import Optional, Dict
+from pydantic import BaseModel, EmailStr, Field
+from typing import Literal, Optional, Dict
+
+class PrivacyUpdateRequest(BaseModel):
+    privacy_settings: Literal["open", "semi", "closed"]
+
+class StandardResponse(BaseModel):
+    success: bool
+    error: Optional[str] = None
 
 class UserCreate(BaseModel):
     email: EmailStr
@@ -38,3 +45,6 @@ class DeleteUserResponse(BaseModel):
     success: bool
     data: Optional[Dict[str, int]]
     error: Optional[str]
+
+class ViewUpdateRequest(BaseModel):
+    view_settings: Literal["all", "follows", "self"]


### PR DESCRIPTION
## 🔀 PR 유형
- [ ] FIX (버그 수정)
- [x] FEAT (신규 기능)

## 📌 PR 목적
- 팔로우 기능, 공개 설정 및 보기 기능을 구현합니다.

## 📝 주요 변경 사항
- 유저 엔티티의 필드에 "공개 설정", "보기 설정" 이 추가됩니다.
- "공개 설정"은 세 가지입니다. "전체 공개(기본값)", "일부 공개", "비공개"
- 전체 공개 시 팔로우 요청을 자동으로 승인합니다. 일부 공개 시 따로 승인해야 합니다. 비공개시 팔로우 요청을 받지 않고, 유저 검색(/search) 의 대상이 되지도 않습니다. (이에 따라 /search API 역시 수정했습니다.)
- "보기 설정" 역시 세가지입니다. "전체 보기", "팔로우만 보기", "나만 보기"
- "전체 보기" 시 모든 유저의 메모를 표시합니다. "팔로우만 보기" 시 본인이 팔로우 하는 사람들의 메모만 봅니다. "나만 보기" 시 내 메모만 봅니다.
- "보기 설정" 의 메모 구현은 @calmkeep22 이 /nearby-me API 구현 시 참고해야 합니다.
- API에 팔로우 관련 메소드가 추가됩니다.
- 팔로우는 follower_id(팔로우하는 사람), following_id(팔로잉당하는 사람), is_approved(승인 여부) 로 이루어집니다.
- 각 API는 is_approved의 컨트롤과, 해당 followentity 자체의 삭제를 다룹니다. (명세서 참고 바람)
- 팔로우 리스트, 팔로워 리스트 보기 API의 response에 따른 프론트엔드가 구현할 부분 역시 API 명세서에 적어뒀으니 참고 바랍니다.

## ✅ 체크리스트
- [ ] 동일 상황에서 재현되지 않음 확인  
- [x] 단위 테스트/수동 테스트 통과  
- [ ] 문서(README 등) 업데이트  
- [ ] 스크린샷/동영상 첨부 (필요 시)  

## 🔍 검토 요청
- 리뷰어: @PokingTeemo 
